### PR TITLE
feat: Implementa camada de permissões nas ViewSets da API

### DIFF
--- a/blog_api/api/serializers.py
+++ b/blog_api/api/serializers.py
@@ -16,4 +16,13 @@ class CategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Category
         fiels = ['id', 'name']
-        
+
+class PostSerializer(serializers.ModelSerializer):
+    class Meta:
+        author = UserSerializer(read_only=True)
+        category = CategorySerializer()
+        tags = TagSerializer(many=True)
+
+        class Meta:
+            model = Post
+            fields = ['id', 'title', 'content', 'author', 'tags', 'published_at']

--- a/blog_api/api/views.py
+++ b/blog_api/api/views.py
@@ -1,3 +1,39 @@
-from django.shortcuts import render
+from rest_framework import viewsets, permissions
+from .serializers import PostSerializer, TagSerializer, CategorySerializer
+from .models import Post, Tag, Category
 
-# Create your views here.
+
+class PostViewSet(viewsets.ModelViewSet):
+    """
+     ViewSet para Posts com permissões dinâmicas:
+    - Apenas Admins podem criar novos posts.
+    - Leitura é pública.
+    - Apenas usuários autenticados podem editar ou deletar.
+    """
+
+    queryset = Post.objects.all().select_related('author', 'category').prefetch_related('tags')
+    serializer_class = PostSerializer
+
+    def get_permissions(self):
+        """
+        Instancia e retorna a lista de permissões que esta view requer,
+        baseado na ação (request method).
+        """
+        permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+        if self.action == 'create':
+            permission_classes = [permissions.IsAdminUser]
+
+        return [permission() for permission in permission_classes]
+
+
+class TagViewSet(viewsets.ModelViewSet):
+    queryset = Tag.objects.all()
+    serializer_class = TagSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
+
+
+class CategoryViewSet(viewsets.ModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]


### PR DESCRIPTION
## O que esse PR faz?
- Este PR introduz uma camada de segurança e controle de acesso às ViewSets da API (Post, Tag e Category), que anteriormente estavam abertas para modificação por qualquer usuário.

- O objetivo é garantir que apenas usuários autorizados possam realizar operações de escrita (Criação, Edição, Deleção) e que regras de negócio específicas, como a criação de Posts apenas por administradores, sejam aplicadas.

- Esse PR introduz tambem as Views.
